### PR TITLE
fix(api): :bug: fixed cors headers and options requests

### DIFF
--- a/api/v2/config.php
+++ b/api/v2/config.php
@@ -1,8 +1,17 @@
 <?php
+
 declare(strict_types=1);
 
 header("Access-Control-Allow-Origin: *");
+header("Access-Control-Allow-Headers: *");
+header("Access-Control-Allow-Methods: *");
 header("Content-Type: application/json");
+
+// Check if request method is OPTIONS. If so, die directly, so that no other code gets executed.
+if ($_SERVER["REQUEST_METHOD"] === "OPTIONS") {
+	die;
+}
+
 
 require 'classes/exception_handler_class.php';
 require 'classes/response_keys_class.php';
@@ -40,15 +49,13 @@ function getData($method, $requirements = [])
 	if (empty($input))
 		throw new CustomException(Response::REQUIRED_DATA_MISSING, "REQUIRED_DATA_MISSING", 400);
 
-	if (isset($requirements) && $input)
-	{
+	if (isset($requirements) && $input) {
 		$errors = [];
 		foreach ($requirements as $r) {
 			if (!array_key_exists($r, $input) || empty($input[$r]))
 				array_push($errors, $r);
 		}
-		if (!empty($errors))
-		{
+		if (!empty($errors)) {
 			$errors = implode(", ", $errors);
 			throw new CustomException(Response::REQUIRED_DATA_MISSING . " ($errors)", "REQUIRED_DATA_MISSING", 400);
 		}
@@ -84,7 +91,7 @@ function authorize($file = null)
 
 	if (!$file)
 		return true;
-	
+
 	// check if token has the right permissions:
 	$sql = "SELECT * FROM property_token_permissions WHERE permission_text = '{$file}'";
 	$sth = $pdo->prepare($sql);

--- a/api/v2/config.php
+++ b/api/v2/config.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 header("Access-Control-Allow-Origin: *");
 header("Access-Control-Allow-Headers: *");
 header("Access-Control-Allow-Methods: *");
+header("Access-Control-Max-Age: 6000");
 header("Content-Type: application/json");
 
 // Check if request method is OPTIONS. If so, die directly, so that no other code gets executed.


### PR DESCRIPTION
Added following headers to every request:
```php
header("Access-Control-Allow-Origin: *");
header("Access-Control-Allow-Headers: *");
header("Access-Control-Allow-Methods: *");
header("Content-Type: application/json");
```

Let the request end when method is options after setting the headers:
```php
header("Access-Control-Allow-Origin: *");
header("Access-Control-Allow-Headers: *");
header("Access-Control-Allow-Methods: *");
header("Content-Type: application/json");

// Check if request method is OPTIONS. If so, die directly, so that no other code gets executed.
if ($_SERVER["REQUEST_METHOD"] === "OPTIONS") {
	die;
}
```